### PR TITLE
Fix build error

### DIFF
--- a/tools/generate-dwconv-multipass-test.py
+++ b/tools/generate-dwconv-multipass-test.py
@@ -399,7 +399,7 @@ def main(args):
       },
   ))
 
-  tests += f'#include "{xnncommon.xnnpack_src()}/{folder}/{options.ukernel}.h"\n'
+  tests += f'#include "{folder}/{options.ukernel}.h"\n'
   tests += "#undef XNN_UKERNEL_WITH_PARAMS\n"
 
   xnncommon.overwrite_if_changed(options.output, tests)

--- a/tools/generate-dwconv-unipass-test.py
+++ b/tools/generate-dwconv-unipass-test.py
@@ -325,7 +325,7 @@ def main(args):
       },
   ))
 
-  tests += f'#include "{xnncommon.xnnpack_src()}/{folder}/{options.ukernel}.h"\n'
+  tests += f'#include "{folder}/{options.ukernel}.h"\n'
   tests += "#undef XNN_UKERNEL_WITH_PARAMS\n"
 
   xnncommon.overwrite_if_changed(options.output, tests)

--- a/tools/generate-vbinary-test.py
+++ b/tools/generate-vbinary-test.py
@@ -146,9 +146,9 @@ def main(args):
   ))
 
   folder = datatype + "-" + ("vbinary" if datatype.startswith("f") else op)
-  tests += f'#include "{xnncommon.xnnpack_src()}/{folder}/{options.ukernel}.h"\n'
+  tests += f'#include "{folder}/{options.ukernel}.h"\n'
   tests += "#undef XNN_UKERNEL_WITH_PARAMS\n"
-  tests = tests.replace("src/s32-vmulc/s32-vmulc.h", "src/s32-vmul/s32-vmulc.h")
+  tests = tests.replace("s32-vmulc/s32-vmulc.h", "s32-vmul/s32-vmulc.h")
 
   xnncommon.overwrite_if_changed(options.output, tests)
 

--- a/tools/generate-vunary-test.py
+++ b/tools/generate-vunary-test.py
@@ -250,7 +250,7 @@ using TestInfo = {op_type};
   if "rnd" in folder:
     folder = folder[0:8]
 
-  tests += f'#include "{xnncommon.xnnpack_src()}/{folder}/{options.ukernel}.h"\n'
+  tests += f'#include "{folder}/{options.ukernel}.h"\n'
   tests += "#undef XNN_UKERNEL_WITH_PARAMS\n"
 
   xnncommon.overwrite_if_changed(options.output, tests)


### PR DESCRIPTION
Removes  {xnncommon.xnnpack_src()} from tests += f'#include "{xnncommon.xnnpack_src()}/{folder}/{options.ukernel}.h"\n' from:
 1. generate-vbinary-test.py
 2. generate-vunary-test.py 
 3. generate-dwconv-unipass-test.py
 4. generate-dwconv-multipass-test.py